### PR TITLE
Potential fix for code scanning alert no. 2: CSRF protection weakened or disabled

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery
+  protect_from_forgery with: :exception
 end


### PR DESCRIPTION
Potential fix for [https://github.com/almondbutter/otown/security/code-scanning/2](https://github.com/almondbutter/otown/security/code-scanning/2)

In general, the fix is to ensure that CSRF protection uses the strongest standard Rails mechanism, which is raising an exception when an invalid CSRF token is encountered. In Rails, that means calling `protect_from_forgery with: :exception` (or not overriding the framework default in versions where that is already set). This prevents the app from silently continuing with a nulled session, which can leave memoized or cached session-derived state intact and exploitable.

For this specific file, the best minimal change is to adjust the existing `protect_from_forgery` call on line 2 of `app/controllers/application_controller.rb` to include the `with: :exception` option. No other functionality needs to change: we keep CSRF protection enabled globally on `ApplicationController`, but make its behavior explicit and secure. No additional imports or methods are required since `protect_from_forgery` and `:exception` are built-in to `ActionController::Base`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
