### PR TITLE
Potential fix for code scanning alert no. 1: Stored cross-site scripting

### DIFF
--- a/app/views/links/show.html.erb
+++ b/app/views/links/show.html.erb
@@ -2,9 +2,21 @@
 	<h3>Event:  </h3><h1><%= @link.title %></h1>
   <h3>Where:  </h3><h1><%= @link.location %></h1>
   <h3>When:  </h3><h1><%= @link.datetime %></h1>
-  <% link_href = @link.url %>
-  <% link_href = "http://#{link_href}" unless link_href.match(/^https?:\/\//) %>
+  <% raw_url   = @link.url.to_s %>
+  <% begin %>
+  <%   uri = URI.parse(raw_url) %>
+  <%   if uri.scheme.nil? %>
+  <%     uri = URI.parse("http://#{raw_url}") %>
+  <%   end %>
+  <%   link_href = (uri.scheme == 'http' || uri.scheme == 'https') ? uri.to_s : nil %>
+  <% rescue URI::InvalidURIError %>
+  <%   link_href = nil %>
+  <% end %>
+  <% if link_href.present? %>
 	<%= link_to @link.url, link_href %><br />
+  <% else %>
+	<%= @link.url %><br />
+  <% end %>
 	<p>Posted at <%= @link.user %><%= @link.created_at %></p>
 </p>
 


### PR DESCRIPTION
Potential fix for [https://github.com/almondbutter/otown/security/code-scanning/1](https://github.com/almondbutter/otown/security/code-scanning/1)

In general, the fix is to ensure `@link.url` is a safe HTTP(S) URL before using it in `link_to`. That means parsing and validating the scheme (and potentially the host) rather than blindly trusting any stored string. If the value is not a valid HTTP(S) URL, we should either not render it as a link or fall back to a safe placeholder.

The best minimal fix here is to replace the manual string manipulation with `URI.parse` and check that the scheme is `http` or `https`. If parsing fails or the scheme is something else (including `javascript:`), we do not use it as a link target. This preserves existing functionality for normal URLs while blocking dangerous schemes. We should also explicitly convert the URL object back to a string with `to_s`. Since we can’t edit any other files, this validation must be done directly in `app/views/links/show.html.erb`. Ruby’s `URI` module is part of the standard library; we can safely `require 'uri'` inside the template if necessary, or reference `URI` if already loaded.

Concretely, in `app/views/links/show.html.erb` we will:
- Replace lines 5–7 with code that:
  - Parses `@link.url` using `URI.parse` in a `begin/rescue` block.
  - Enforces an `http` or `https` scheme (adding `http://` if no scheme is provided).
  - Falls back to `nil` if invalid.
- Only call `link_to` if `link_href` is present and valid; otherwise, render the URL as escaped text.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
